### PR TITLE
SS6 compatibility: bump framework to ^6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"issues": "https://github.com/axllent/silverstripe-bootstrap-forms/issues"
 	},
 	"require": {
-		"silverstripe/framework": "^4.0 || ^5.0"
+		"silverstripe/framework": "^4.0 || ^5.0 || ^6.0"
 	},
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Update framework constraint from ^4||^5 to ^6 for SilverStripe 6 compatibility.